### PR TITLE
Return the Cognito username instead of `sub` for `getId`

### DIFF
--- a/src/CognitoUser.php
+++ b/src/CognitoUser.php
@@ -13,7 +13,7 @@ class CognitoUser extends AbstractResourceOwner
 {
     public function getId(): string
     {
-        return $this->get('sub');
+        return $this->get('username', $this->get('cognito:username'));
     }
 
     public function getAddress(): ?string


### PR DESCRIPTION
**Description of the change:**
<!-- Replace this with a short description of what the PR includes. -->
The identifier Cognito sends via. the API is always the username; This change will ensure the `getId` on the resource owner will return the username to ensure consistency throughout the packages.
