### PR TITLE
Add date handling for attributes

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -436,6 +436,10 @@ class Client implements OAuthClientInterface
             return $value ? 'true' : 'false';
         }
 
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s e');
+        }
+
         return (string) $value;
     }
 

--- a/tests/AttributesAreProvidedInCorrectFormatTest.php
+++ b/tests/AttributesAreProvidedInCorrectFormatTest.php
@@ -71,6 +71,15 @@ class AttributesAreProvidedInCorrectFormatTest extends TestCase
             ],
         ];
 
+        $date = new \DateTime();
+
+        yield [
+            ['Key1' => $date],
+            [
+                ['Name' => 'Key1', 'Value' => $date->format('Y-m-d H:i:s e')],
+            ],
+        ];
+
         yield [
             [],
             []


### PR DESCRIPTION
<!--
Ensure you have read the Contributing Guide and Code of Conduct, and:
 - Added tests covering the introduced code and ensure they pass.
 - Have not broke backward compatibility.
-->

| Q                | A
| ---------------- | ---
| Type             | Feature

**Description of the change:**
<!-- Replace this with a short description of what the PR includes. -->

This PR will allow `DateTime` objects to be passed to `register` or `changeAttributes` to be formatted per the vendor's requirements. This requirement is bespoke and is different for all 3 of our adapters, which is why it seems better to handle the dates within this class.

