### PR TITLE
Use guzzle to fetch Jwt Web Keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "aws/aws-sdk-php": "^3.183.7",
     "dvsa/contracts": "^1.1",
     "firebase/php-jwt": "^5.2",
-    "guzzlehttp/guzzle": "^7.3",
+    "guzzlehttp/guzzle": "^6.0 || ^7.0",
     "league/oauth2-client": "^2.6"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "aws/aws-sdk-php": "^3.183.7",
     "dvsa/contracts": "^1.1",
     "firebase/php-jwt": "^5.2",
+    "guzzlehttp/guzzle": "^7.3",
     "league/oauth2-client": "^2.6"
   },
   "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,6 +15,7 @@ use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Response;
 
 class Client implements OAuthClientInterface
@@ -402,12 +403,8 @@ class Client implements OAuthClientInterface
 
         try {
             $response = $this->getHttpClient()->get($url);
-        } catch (GuzzleException $e) {
+        } catch (TransferException $e) {
             throw new \Exception(sprintf('Unable to fetch JWT web keys: %s', $e->getMessage()), (int)$e->getCode(), $e);
-        }
-
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception(sprintf('Unable to fetch JWT web keys. Status code %d', $response->getStatusCode()));
         }
 
         $body = $response->getBody()->getContents();

--- a/src/Client.php
+++ b/src/Client.php
@@ -13,6 +13,9 @@ use Dvsa\Contracts\Auth\OAuthClientInterface;
 use Dvsa\Contracts\Auth\ResourceOwnerInterface;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Response;
 
 class Client implements OAuthClientInterface
 {
@@ -29,7 +32,7 @@ class Client implements OAuthClientInterface
     /**
      * @var CognitoIdentityProviderClient
      */
-    protected $client;
+    protected $cognitoClient;
 
     /**
      * @var string
@@ -51,16 +54,23 @@ class Client implements OAuthClientInterface
      */
     protected $jwtWebKeys = [];
 
+    /**
+     * @var HttpClient
+     */
+    private $httpClient;
+
     public function __construct(
-        CognitoIdentityProviderClient $client,
+        CognitoIdentityProviderClient $cognitoClient,
         string $clientId,
         string $clientSecret,
-        string $poolId
+        string $poolId,
+        HttpClient $httpClient
     ) {
-        $this->client = $client;
+        $this->cognitoClient = $cognitoClient;
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
         $this->poolId = $poolId;
+        $this->httpClient = $httpClient;
 
         $this->resourceOwnerClass = CognitoUser::class;
     }
@@ -73,7 +83,7 @@ class Client implements OAuthClientInterface
     public function register(string $identifier, string $password, array $attributes = []): ResourceOwnerInterface
     {
         try {
-            $response = $this->client->adminCreateUser([
+            $response = $this->cognitoClient->adminCreateUser([
                 'MessageAction' => 'SUPPRESS',
                 'TemporaryPassword' => $password,
                 'UserAttributes' => $this->formatAttributes($attributes),
@@ -97,7 +107,7 @@ class Client implements OAuthClientInterface
     public function authenticate(string $identifier, string $password): AccessTokenInterface
     {
         try {
-            $response = $this->client->adminInitiateAuth(
+            $response = $this->cognitoClient->adminInitiateAuth(
                 [
                     'AuthFlow'       => 'ADMIN_USER_PASSWORD_AUTH',
                     'AuthParameters' => [
@@ -125,7 +135,7 @@ class Client implements OAuthClientInterface
     public function responseToAuthChallenge(string $challengeName, array $challengeResponses, string $session): AccessTokenInterface
     {
         try {
-            $response = $this->client->adminRespondToAuthChallenge(
+            $response = $this->cognitoClient->adminRespondToAuthChallenge(
                 [
                     'ChallengeName'      => $challengeName,
                     'ChallengeResponses' => $challengeResponses,
@@ -148,7 +158,7 @@ class Client implements OAuthClientInterface
     public function changePassword(string $identifier, string $newPassword, bool $permanent = true): bool
     {
         try {
-            $this->client->adminSetUserPassword([
+            $this->cognitoClient->adminSetUserPassword([
                 'Username' => $identifier,
                 'UserPoolId' => $this->poolId,
                 'Password' => $newPassword,
@@ -177,7 +187,7 @@ class Client implements OAuthClientInterface
     public function changeAttributes(string $identifier, array $attributes): bool
     {
         try {
-            $this->client->adminUpdateUserAttributes([
+            $this->cognitoClient->adminUpdateUserAttributes([
                 'Username' => $identifier,
                 'UserPoolId' => $this->poolId,
                 'UserAttributes' => $this->formatAttributes($attributes)
@@ -197,7 +207,7 @@ class Client implements OAuthClientInterface
     public function enableUser(string $identifier): bool
     {
         try {
-            $this->client->adminEnableUser([
+            $this->cognitoClient->adminEnableUser([
                 'Username' => $identifier,
                 'UserPoolId' => $this->poolId,
             ]);
@@ -216,7 +226,7 @@ class Client implements OAuthClientInterface
     public function disableUser(string $identifier): bool
     {
         try {
-            $this->client->adminDisableUser([
+            $this->cognitoClient->adminDisableUser([
                 'Username' => $identifier,
                 'UserPoolId' => $this->poolId,
             ]);
@@ -235,7 +245,7 @@ class Client implements OAuthClientInterface
     public function getUserByIdentifier(string $identifier): ResourceOwnerInterface
     {
         try {
-            $response = $this->client->adminGetUser([
+            $response = $this->cognitoClient->adminGetUser([
                 'UserPoolId' => $this->poolId,
                 'Username' => $identifier
             ]);
@@ -279,7 +289,7 @@ class Client implements OAuthClientInterface
             throw new InvalidTokenException('"token_use" invalid');
         }
 
-        $expectedIss = sprintf('https://cognito-idp.%s.amazonaws.com/%s', $this->client->getRegion(), $this->poolId);
+        $expectedIss = sprintf('https://cognito-idp.%s.amazonaws.com/%s', $this->cognitoClient->getRegion(), $this->poolId);
         if (!isset($tokenClaims['iss']) || $tokenClaims['iss'] !== $expectedIss) {
             throw new InvalidTokenException('"iss" invalid');
         }
@@ -316,7 +326,7 @@ class Client implements OAuthClientInterface
     public function refreshTokens(string $refreshToken, string $identifier): AccessTokenInterface
     {
         try {
-            $response = $this->client->adminInitiateAuth([
+            $response = $this->cognitoClient->adminInitiateAuth([
                 'AuthFlow' => 'REFRESH_TOKEN_AUTH',
                 'AuthParameters' => [
                     'REFRESH_TOKEN' => $refreshToken,
@@ -369,17 +379,26 @@ class Client implements OAuthClientInterface
     {
         $url = sprintf(
             'https://cognito-idp.%s.amazonaws.com/%s/.well-known/jwks.json',
-            $this->client->getRegion(),
+            $this->cognitoClient->getRegion(),
             $this->poolId
         );
 
-        $json = file_get_contents($url);
+        try {
+            $response = $this->httpClient->get($url);
+        } catch (GuzzleException $e) {
+            throw new \Exception(sprintf('Unable to fetch JWT web keys: %s', $e->getMessage()), (int)$e->getCode(), $e);
+        }
 
-        if (false === $json) {
+        if ($response->getStatusCode() !== 200) {
+            throw new \Exception(sprintf('Unable to fetch JWT web keys. Status code %d', $response->getStatusCode()));
+        }
+
+        $body = $response->getBody()->getContents();
+        if (empty($body)) {
             return [];
         }
 
-        $keys = json_decode($json, true);
+        $keys = json_decode($body, true);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new \JsonException(sprintf('Invalid JSON rules input: "%s".', json_last_error_msg()));

--- a/src/Client.php
+++ b/src/Client.php
@@ -55,22 +55,20 @@ class Client implements OAuthClientInterface
     protected $jwtWebKeys = [];
 
     /**
-     * @var HttpClient
+     * @var HttpClient|null
      */
-    private $httpClient;
+    private $httpClient = null;
 
     public function __construct(
         CognitoIdentityProviderClient $cognitoClient,
         string $clientId,
         string $clientSecret,
-        string $poolId,
-        HttpClient $httpClient
+        string $poolId
     ) {
         $this->cognitoClient = $cognitoClient;
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
         $this->poolId = $poolId;
-        $this->httpClient = $httpClient;
 
         $this->resourceOwnerClass = CognitoUser::class;
     }
@@ -365,6 +363,25 @@ class Client implements OAuthClientInterface
     }
 
     /**
+     * @param HttpClient $httpClient
+     */
+    public function setHttpClient(HttpClient $httpClient): void
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @return HttpClient
+     */
+    public function getHttpClient(): HttpClient
+    {
+        if (is_null($this->httpClient)) {
+            $this->httpClient = new HttpClient();
+        }
+        return $this->httpClient;
+    }
+
+    /**
      * @return string[]
      */
     protected function parseJwk(array $keys): array
@@ -384,7 +401,7 @@ class Client implements OAuthClientInterface
         );
 
         try {
-            $response = $this->httpClient->get($url);
+            $response = $this->getHttpClient()->get($url);
         } catch (GuzzleException $e) {
             throw new \Exception(sprintf('Unable to fetch JWT web keys: %s', $e->getMessage()), (int)$e->getCode(), $e);
         }

--- a/tests/AttributesAreProvidedInCorrectFormatTest.php
+++ b/tests/AttributesAreProvidedInCorrectFormatTest.php
@@ -38,10 +38,11 @@ class AttributesAreProvidedInCorrectFormatTest extends TestCase
             'handler' => $this->mockHandler
         ]);
 
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+
         $handlerStack = HandlerStack::create(new MockHttpHandler());
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
+        $this->client->setHttpClient($httpClient);
     }
 
     /**

--- a/tests/AttributesAreProvidedInCorrectFormatTest.php
+++ b/tests/AttributesAreProvidedInCorrectFormatTest.php
@@ -8,6 +8,9 @@ use Aws\Credentials\Credentials;
 use Aws\MockHandler;
 use Aws\Result;
 use Dvsa\Authentication\Cognito\Client;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
+use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 
 class AttributesAreProvidedInCorrectFormatTest extends TestCase
@@ -35,7 +38,10 @@ class AttributesAreProvidedInCorrectFormatTest extends TestCase
             'handler' => $this->mockHandler
         ]);
 
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+        $handlerStack = HandlerStack::create(new MockHttpHandler());
+        $httpClient = new HttpClient(['handler' => $handlerStack]);
+
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
     }
 
     /**

--- a/tests/AuthenticateReturnsExpectedResponseTest.php
+++ b/tests/AuthenticateReturnsExpectedResponseTest.php
@@ -41,10 +41,11 @@ class AuthenticateReturnsExpectedResponseTest extends TestCase
             'handler' => $this->mockHandler
         ]);
 
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+
         $handlerStack = HandlerStack::create(new MockHttpHandler());
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
+        $this->client->setHttpClient($httpClient);
     }
 
     public function testAuthenticateActionWillReturnAccessToken(): void

--- a/tests/AuthenticateReturnsExpectedResponseTest.php
+++ b/tests/AuthenticateReturnsExpectedResponseTest.php
@@ -11,6 +11,9 @@ use Dvsa\Authentication\Cognito\Client;
 use Dvsa\Contracts\Auth\AccessTokenInterface;
 use Dvsa\Contracts\Auth\Exceptions\ChallengeException;
 use Dvsa\Contracts\Auth\Exceptions\ClientException;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
+use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 
 class AuthenticateReturnsExpectedResponseTest extends TestCase
@@ -38,7 +41,10 @@ class AuthenticateReturnsExpectedResponseTest extends TestCase
             'handler' => $this->mockHandler
         ]);
 
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+        $handlerStack = HandlerStack::create(new MockHttpHandler());
+        $httpClient = new HttpClient(['handler' => $handlerStack]);
+
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
     }
 
     public function testAuthenticateActionWillReturnAccessToken(): void

--- a/tests/ContractExceptionsAreThrownInsteadTest.php
+++ b/tests/ContractExceptionsAreThrownInsteadTest.php
@@ -39,10 +39,11 @@ class ContractExceptionsAreThrownInsteadTest extends TestCase
             'handler' => $this->mockHandler
         ]);
 
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+
         $handlerStack = HandlerStack::create(new MockHttpHandler());
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
+        $this->client->setHttpClient($httpClient);
     }
 
     /**

--- a/tests/ContractExceptionsAreThrownInsteadTest.php
+++ b/tests/ContractExceptionsAreThrownInsteadTest.php
@@ -9,6 +9,9 @@ use Aws\Exception\AwsException;
 use Aws\MockHandler;
 use Dvsa\Authentication\Cognito\Client;
 use Dvsa\Contracts\Auth\Exceptions\ClientException;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
+use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 
 class ContractExceptionsAreThrownInsteadTest extends TestCase
@@ -36,7 +39,10 @@ class ContractExceptionsAreThrownInsteadTest extends TestCase
             'handler' => $this->mockHandler
         ]);
 
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+        $handlerStack = HandlerStack::create(new MockHttpHandler());
+        $httpClient = new HttpClient(['handler' => $handlerStack]);
+
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
     }
 
     /**

--- a/tests/ResourceOwnerObjectReturnedFromMethodsTest.php
+++ b/tests/ResourceOwnerObjectReturnedFromMethodsTest.php
@@ -42,10 +42,11 @@ class ResourceOwnerObjectReturnedFromMethodsTest extends TestCase
             ]
         );
 
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+
         $handlerStack = HandlerStack::create(new MockHttpHandler());
         $httpClient = new HttpClient(['handler' => $handlerStack]);
-
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
+        $this->client->setHttpClient($httpClient);
     }
 
     public function testGetUserByIdentifierReturnsResourceOwnerObject(): void

--- a/tests/ResourceOwnerObjectReturnedFromMethodsTest.php
+++ b/tests/ResourceOwnerObjectReturnedFromMethodsTest.php
@@ -8,6 +8,9 @@ use Aws\MockHandler;
 use Aws\Result;
 use Dvsa\Authentication\Cognito\Client;
 use Dvsa\Authentication\Cognito\CognitoUser;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
+use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 
 class ResourceOwnerObjectReturnedFromMethodsTest extends TestCase
@@ -39,7 +42,10 @@ class ResourceOwnerObjectReturnedFromMethodsTest extends TestCase
             ]
         );
 
-        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+        $handlerStack = HandlerStack::create(new MockHttpHandler());
+        $httpClient = new HttpClient(['handler' => $handlerStack]);
+
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID', $httpClient);
     }
 
     public function testGetUserByIdentifierReturnsResourceOwnerObject(): void

--- a/tests/TokenValidityTest.php
+++ b/tests/TokenValidityTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -150,19 +151,20 @@ EOF;
         $this->client->decodeToken($encoded);
     }
 
-    public function testDecodeWillThrowExceptionWhenUnableToFetchJwtWebKeys()
+    public function testDecodeWillThrowExceptionWhenUnableToFetchJwtWebKeys(): void
     {
         $this->client->setJwtWebKeys([]);
 
         $mockHttpHandler = new MockHttpHandler();
-        $handlerStack = HandlerStack::create($this->mockHttpHandler);
-        $mockHttpHandler->append(new RequestException('Error Communicating with Server', new Request('GET', 'test')));
+        $exceptionMessage = 'Error Communicating with Server';
+        $mockHttpHandler->append(new RequestException($exceptionMessage, new Request('GET', 'test')));
+        $handlerStack = HandlerStack::create($mockHttpHandler);
         $httpClient = new HttpClient(['handler' => $handlerStack]);
 
         $this->client->setHttpClient($httpClient);
 
         $this->expectException(InvalidTokenException::class);
-        $this->expectErrorMessage('Unable to fetch JWT web keys');
+        $this->expectErrorMessage(sprintf('Unable to fetch JWT web keys: %s', $exceptionMessage));
 
         $this->client->decodeToken('');
     }


### PR DESCRIPTION

| Q                | A
| ---------------- | ---
| Type             |  Feature
| Ticket           | VOL-2381

**Description of the change:**
Due to the use of a proxy for outbound requests within VOL we need to replace the call to fetch JWT Web Keys with guzzle to allow it go via the proxy. 

