### PR TITLE
removed 7.2 php support from testing action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0']
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}


### PR DESCRIPTION


| Q                | A
| ---------------- | ---
| Type             | Feature
| Ticket           | n/a

**Description of the change:**
Removed the action testing 7.2 as 7.3 now current minimum requirment.

