### PR TITLE
Add missing UserPoolId in AdminRespondToAuthChallenge

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -140,6 +140,7 @@ class Client implements OAuthClientInterface
                     'ChallengeResponses' => $challengeResponses,
                     'ClientId'           => $this->clientId,
                     'Session'            => $session,
+                    'UserPoolId'         => $this->poolId
                 ]
             );
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -140,7 +140,7 @@ class Client implements OAuthClientInterface
                     'ChallengeResponses' => $challengeResponses,
                     'ClientId'           => $this->clientId,
                     'Session'            => $session,
-                    'UserPoolId'         => $this->poolId
+                    'UserPoolId'         => $this->poolId,
                 ]
             );
 


### PR DESCRIPTION
<!--
Ensure you have read the Contributing Guide and Code of Conduct, and:
 - Added tests covering the introduced code and ensure they pass.
 - Have not broke backward compatibility.
-->

| Q                | A
| ---------------- | ---
| Type             | Bugfix 
| Ticket           | VOL-247

**Description of the change:**
AdminRespondToAuthChallenge requires UserPoolId to be passed

