### PR TITLE
Send secret hash in challenge response if doesn't already exist

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -134,6 +134,15 @@ class Client implements OAuthClientInterface
     public function responseToAuthChallenge(string $challengeName, array $challengeResponses, string $session): AccessTokenInterface
     {
         try {
+            $identifier = $challengeResponses['USERNAME'] ?? null;
+            if (empty($identifier)) {
+                throw new ClientException("ChallengeResponse must contain 'USERNAME'");
+            }
+
+            if (!array_key_exists('SECRET_HASH', $challengeResponses)) {
+                $challengeResponses['SECRET_HASH'] = $this->cognitoSecretHash($identifier);
+            }
+
             $response = $this->cognitoClient->adminRespondToAuthChallenge(
                 [
                     'ChallengeName'      => $challengeName,


### PR DESCRIPTION
<!--
Ensure you have read the Contributing Guide and Code of Conduct, and:
 - Added tests covering the introduced code and ensure they pass.
 - Have not broke backward compatibility.
-->

| Q                | A
| ---------------- | ---
| Type             | Bugfix
| Ticket           | NA

**Description of the change:**
Challenge response require the secret hash to be sent as part of the challenge response

