### PR TITLE
Add ability to cache JWK

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.0'
           coverage: none
           extensions: mbstring
 
@@ -41,6 +41,6 @@ jobs:
 
       - name: Upload result to GitHub Code Scanning
         if: ${{ success() || failure() }}
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.0'
           coverage: none
           extensions: mbstring, intl
 
@@ -44,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.0'
           coverage: none
           extensions: mbstring
 
@@ -68,7 +68,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.0'
           coverage: none
           extensions: mbstring, intl
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,18 @@
     }
   ],
   "require": {
-    "php": "^7.2.5 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "ext-json": "*",
-    "aws/aws-sdk-php": "^3.183.7",
+    "aws/aws-sdk-php": "^3.199.0",
     "dvsa/contracts": "^1.1",
-    "firebase/php-jwt": "^5.2",
-    "guzzlehttp/guzzle": "^6.0 || ^7.0",
-    "league/oauth2-client": "^2.6"
+    "firebase/php-jwt": "^6.3",
+    "guzzlehttp/guzzle": "^7.4.5",
+    "guzzlehttp/psr7": "^2.0",
+    "illuminate/collections": "^8.0",
+    "league/oauth2-client": "^2.6",
+    "psr/cache": "^1.0 || ^3.0",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -31,12 +36,15 @@
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4",
-    "phpunit/phpunit": "^8.5"
+    "phpunit/phpunit": "^9.5.4"
   },
   "config": {
     "sort-packages": true,
     "optimize-autoloader": true,
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "allow-plugins": {
+      "bamarni/composer-bin-plugin": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -14,10 +14,7 @@ use League\OAuth2\Client\Token\AccessToken as BaseAccessToken;
  */
 class AccessToken extends BaseAccessToken implements AccessTokenInterface
 {
-    /**
-     * @var null|string
-     */
-    protected $idToken;
+    protected ?string $idToken = null;
 
     /**
      * @inheritDoc

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,45 +30,22 @@ class Client implements OAuthClientInterface
     /**
      * When checking nbf, iat or expiration times on tokens, we want to provide
      * some extra leeway time to account for clock skew.
-     *
-     * @var int
      */
-    public static $leeway = 0;
+    public static int $leeway = 0;
 
-    /**
-     * @var CognitoIdentityProviderClient
-     */
-    protected $cognitoClient;
+    protected CognitoIdentityProviderClient $cognitoClient;
 
-    /**
-     * @var string
-     */
-    protected $clientId;
+    protected string $clientId;
 
-    /**
-     * @var string
-     */
-    protected $clientSecret;
+    protected string $clientSecret;
 
-    /**
-     * @var string
-     */
-    protected $poolId;
+    protected string $poolId;
 
-    /**
-     * @var ArrayAccess|null
-     */
-    protected $jwtWebKeys;
+    protected ?ArrayAccess $jwtWebKeys;
 
-    /**
-     * @var ClientInterface|null
-     */
-    protected $httpClient;
+    protected ?ClientInterface $httpClient;
 
-    /**
-     * @var CacheItemPoolInterface|null
-     */
-    protected $cache = null;
+    protected ?CacheItemPoolInterface $cache;
 
     public function __construct(
         CognitoIdentityProviderClient $cognitoClient,
@@ -402,8 +379,6 @@ class Client implements OAuthClientInterface
     }
 
     /**
-     * @return ArrayAccess<string, Key>
-     *
      * @throws ClientExceptionInterface
      * @throws \JsonException
      */
@@ -441,8 +416,6 @@ class Client implements OAuthClientInterface
     }
 
     /**
-     * @phpstan-return ArrayAccess<string, Key>
-     *
      * @throws ClientExceptionInterface|\JsonException
      */
     protected function downloadJwtWebKeys(): ArrayAccess

--- a/src/Client.php
+++ b/src/Client.php
@@ -41,11 +41,11 @@ class Client implements OAuthClientInterface
 
     protected string $poolId;
 
-    protected ?ArrayAccess $jwtWebKeys;
+    protected ?ArrayAccess $jwtWebKeys = null;
 
-    protected ?ClientInterface $httpClient;
+    protected ?ClientInterface $httpClient = null;
 
-    protected ?CacheItemPoolInterface $cache;
+    protected ?CacheItemPoolInterface $cache = null;
 
     public function __construct(
         CognitoIdentityProviderClient $cognitoClient,

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace Dvsa\Authentication\Cognito;
 
+use ArrayAccess;
 use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
 use Aws\Exception\AwsException;
 use Dvsa\Contracts\Auth\AccessTokenInterface;
@@ -11,12 +12,16 @@ use Dvsa\Contracts\Auth\Exceptions\ClientException;
 use Dvsa\Contracts\Auth\Exceptions\InvalidTokenException;
 use Dvsa\Contracts\Auth\OAuthClientInterface;
 use Dvsa\Contracts\Auth\ResourceOwnerInterface;
+use Firebase\JWT\CachedKeySet;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use GuzzleHttp\Client as HttpClient;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\TransferException;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\HttpFactory;
+use Illuminate\Support\Collection;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
 
 class Client implements OAuthClientInterface
 {
@@ -51,14 +56,19 @@ class Client implements OAuthClientInterface
     protected $poolId;
 
     /**
-     * @var string[]
+     * @var ArrayAccess|null
      */
-    protected $jwtWebKeys = [];
+    protected $jwtWebKeys;
 
     /**
-     * @var HttpClient|null
+     * @var ClientInterface|null
      */
-    private $httpClient = null;
+    protected $httpClient;
+
+    /**
+     * @var CacheItemPoolInterface|null
+     */
+    protected $cache = null;
 
     public function __construct(
         CognitoIdentityProviderClient $cognitoClient,
@@ -292,11 +302,19 @@ class Client implements OAuthClientInterface
     public function decodeToken(string $token): array
     {
         try {
+            /**
+             * The typing of the JWT library is not quite right for `decode()` method for PHPStan as it doesn't accept ArrayAccess.
+             * The following type is required to cast `ArrayAccess<string, Key>` to just an expected `array<string, Key>`.
+             *
+             * Can be removed once fixed in the JWT library.
+             *
+             * @var array<string, Key> $keySet
+             */
             $keySet = $this->getJwtWebKeys();
 
             JWT::$leeway = self::$leeway;
 
-            $tokenClaims = (array) JWT::decode($token, $keySet, ['RS256']);
+            $tokenClaims = (array) JWT::decode($token, $keySet);
 
             $this->validateTokenClaims($tokenClaims);
 
@@ -378,51 +396,56 @@ class Client implements OAuthClientInterface
         }
     }
 
-    public function setJwtWebKeys(array $keys): void
+    public function setJwtWebKeys(?ArrayAccess $keys): void
     {
         $this->jwtWebKeys = $keys;
     }
 
-    public function getJwtWebKeys(): array
+    /**
+     * @return ArrayAccess<string, Key>
+     *
+     * @throws ClientExceptionInterface
+     * @throws \JsonException
+     */
+    public function getJwtWebKeys(): ArrayAccess
     {
         if (empty($this->jwtWebKeys)) {
-            $this->jwtWebKeys = $this->parseJwk($this->downloadJwtWebKeys());
+            $this->jwtWebKeys = $this->downloadJwtWebKeys();
         }
 
         return $this->jwtWebKeys;
     }
 
-    /**
-     * @param HttpClient $httpClient
-     */
-    public function setHttpClient(HttpClient $httpClient): void
+    public function setHttpClient(ClientInterface $httpClient): void
     {
         $this->httpClient = $httpClient;
     }
 
-    /**
-     * @return HttpClient
-     */
-    public function getHttpClient(): HttpClient
+    public function getHttpClient(): ClientInterface
     {
         if (is_null($this->httpClient)) {
             $this->httpClient = new HttpClient();
         }
+
         return $this->httpClient;
     }
 
-    /**
-     * @return string[]
-     */
-    protected function parseJwk(array $keys): array
+    public function setCache(?CacheItemPoolInterface $cache): void
     {
-        return JWK::parseKeySet($keys);
+        $this->cache = $cache;
+    }
+
+    public function getCache(): ?CacheItemPoolInterface
+    {
+        return $this->cache;
     }
 
     /**
-     * @throws \JsonException
+     * @phpstan-return ArrayAccess<string, Key>
+     *
+     * @throws ClientExceptionInterface|\JsonException
      */
-    protected function downloadJwtWebKeys(): array
+    protected function downloadJwtWebKeys(): ArrayAccess
     {
         $url = sprintf(
             'https://cognito-idp.%s.amazonaws.com/%s/.well-known/jwks.json',
@@ -430,15 +453,26 @@ class Client implements OAuthClientInterface
             $this->poolId
         );
 
-        try {
-            $response = $this->getHttpClient()->get($url);
-        } catch (TransferException $e) {
-            throw new \Exception(sprintf('Unable to fetch JWT web keys: %s', $e->getMessage()), (int)$e->getCode(), $e);
+        $factory = new HttpFactory();
+
+        $cache = $this->getCache();
+
+        if ($cache) {
+            return new CachedKeySet(
+                $url,
+                $this->getHttpClient(),
+                $factory,
+                $cache
+            );
         }
+
+        $request = $factory->createRequest('get', $url);
+
+        $response = $this->getHttpClient()->sendRequest($request);
 
         $body = $response->getBody()->getContents();
         if (empty($body)) {
-            return [];
+            return new Collection();
         }
 
         $keys = json_decode($body, true);
@@ -447,7 +481,7 @@ class Client implements OAuthClientInterface
             throw new \JsonException(sprintf('Invalid JSON rules input: "%s".', json_last_error_msg()));
         }
 
-        return $keys;
+        return new Collection(JWK::parseKeySet($keys));
     }
 
     protected function cognitoSecretHash(string $identifier): string

--- a/tests/AttributesAreProvidedInCorrectFormatTest.php
+++ b/tests/AttributesAreProvidedInCorrectFormatTest.php
@@ -5,7 +5,7 @@ namespace Dvsa\Authentication\Cognito\Tests;
 use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
 use Aws\CommandInterface;
 use Aws\Credentials\Credentials;
-use Aws\MockHandler;
+use Aws\MockHandler as AwsMockHandler;
 use Aws\Result;
 use Dvsa\Authentication\Cognito\Client;
 use GuzzleHttp\Client as HttpClient;
@@ -15,19 +15,13 @@ use PHPUnit\Framework\TestCase;
 
 class AttributesAreProvidedInCorrectFormatTest extends TestCase
 {
-    /**
-     * @var MockHandler
-     */
-    protected $mockHandler;
+    protected AwsMockHandler $mockHandler;
 
-    /**
-     * @var Client
-     */
-    protected $client;
+    protected Client $client;
 
     protected function setUp(): void
     {
-        $this->mockHandler = new MockHandler();
+        $this->mockHandler = new AwsMockHandler();
 
         $awsCredentials = new Credentials('AWS_ACCESS_KEY', 'AWS_SECRET_KEY');
 

--- a/tests/AuthenticateReturnsExpectedResponseTest.php
+++ b/tests/AuthenticateReturnsExpectedResponseTest.php
@@ -4,7 +4,7 @@ namespace Dvsa\Authentication\Cognito\Tests;
 
 use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
 use Aws\Credentials\Credentials;
-use Aws\MockHandler;
+use Aws\MockHandler as AwsMockHandler;
 use Aws\Result;
 use Dvsa\Authentication\Cognito\AccessToken;
 use Dvsa\Authentication\Cognito\Client;
@@ -18,19 +18,13 @@ use PHPUnit\Framework\TestCase;
 
 class AuthenticateReturnsExpectedResponseTest extends TestCase
 {
-    /**
-     * @var MockHandler
-     */
-    protected $mockHandler;
+    protected AwsMockHandler $mockHandler;
 
-    /**
-     * @var Client
-     */
-    protected $client;
+    protected Client $client;
 
     protected function setUp(): void
     {
-        $this->mockHandler = new MockHandler();
+        $this->mockHandler = new AwsMockHandler();
 
         $awsCredentials = new Credentials('AWS_ACCESS_KEY', 'AWS_SECRET_KEY');
 

--- a/tests/CachedJWKUsedWhenProvidedWithPSR6InterfaceTest.php
+++ b/tests/CachedJWKUsedWhenProvidedWithPSR6InterfaceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Dvsa\Authentication\Cognito\Tests;
+
+use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
+use Aws\Credentials\Credentials;
+use Aws\MockHandler as AwsMockHandler;
+use Dvsa\Authentication\Cognito\Client;
+use Firebase\JWT\CachedKeySet;
+use Firebase\JWT\JWK;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+
+class CachedJWKUsedWhenProvidedWithPSR6InterfaceTest extends TestCase
+{
+    protected AwsMockHandler $mockHandler;
+
+    protected Client $client;
+
+    protected function setUp(): void
+    {
+        $this->mockHandler = new AwsMockHandler();
+
+        $awsCredentials = new Credentials('AWS_ACCESS_KEY', 'AWS_SECRET_KEY');
+
+        $cognitoIdentityProviderClient = new CognitoIdentityProviderClient([
+            'credentials' => $awsCredentials,
+            'region'  => 'us-west-2',
+            'version' => 'latest',
+            'handler' => $this->mockHandler
+        ]);
+
+        $this->client = new Client($cognitoIdentityProviderClient, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
+
+        $handlerStack = HandlerStack::create(new MockHttpHandler());
+        $httpClient = new HttpClient(['handler' => $handlerStack]);
+        $this->client->setHttpClient($httpClient);
+    }
+
+    public function testCachedJwkUsedWhenCacheInterfaceSet(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+
+        $this->client->setCache($cache);
+
+        $jwk = $this->client->getJwtWebKeys();
+
+        $this->assertInstanceOf(CachedKeySet::class, $jwk);
+    }
+
+    public function testJwkRetrievedEachRequestWhenCacheInterfaceNotSet(): void
+    {
+        $this->client->setJwtWebKeys(
+            new Collection(
+                JWK::parseKeySet([
+                    'keys' => [[
+                        "kid" => "1234example=",
+                        "alg" => "RS256",
+                        "kty" => "RSA",
+                        "e" => "AQAB",
+                        "n" => "0Ttga33B1yX4w77NbpKyNYDNSVCo8j-RlZaZ9tI-KfkV1d-tfsvI9ZPAheP11FoN52ceBaY5ltelHW-IKwCfyT0orLdsxLgowaXki9woF1Azvcg2JVxQLv9aVjjAvy3CZFIG_EeN7J3nsyCXGnu1yMEbnvkWxA88__Q6HQ2K9wqfApkQ0LNlsK0YHz_sfjHNvRKxnbAJk7D5fUhZunPZXOPHXFgA5SvLvMaNIXduMKJh4OMfuoLdJowXJAR9j31Mqz_is4FMhm_9Mq7vZZ-uF09htRvIR8tRY28oJuW1gKWyg7cQQpnjHgFyG3XLXWAeXclWqyh_LfjyHQjrYhyeFw",
+                        "use" => "sig",
+                    ]]
+                ])
+            )
+        );
+
+        $mockHttpHandler = new MockHttpHandler();
+        $mockHttpHandler->append(new Response(200, [], json_encode([])));
+        $handlerStack = HandlerStack::create($mockHttpHandler);
+        $httpClient = new HttpClient(['handler' => $handlerStack]);
+
+        $this->client->setHttpClient($httpClient);
+
+        $jwk = $this->client->getJwtWebKeys();
+
+        $this->assertInstanceOf(Collection::class, $jwk);
+    }
+}

--- a/tests/ContractExceptionsAreThrownInsteadTest.php
+++ b/tests/ContractExceptionsAreThrownInsteadTest.php
@@ -6,7 +6,7 @@ use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
 use Aws\CommandInterface;
 use Aws\Credentials\Credentials;
 use Aws\Exception\AwsException;
-use Aws\MockHandler;
+use Aws\MockHandler as AwsMockHandler;
 use Dvsa\Authentication\Cognito\Client;
 use Dvsa\Contracts\Auth\Exceptions\ClientException;
 use GuzzleHttp\Client as HttpClient;
@@ -16,19 +16,13 @@ use PHPUnit\Framework\TestCase;
 
 class ContractExceptionsAreThrownInsteadTest extends TestCase
 {
-    /**
-     * @var MockHandler
-     */
-    protected $mockHandler;
+    protected AwsMockHandler $mockHandler;
 
-    /**
-     * @var Client
-     */
-    protected $client;
+    protected Client $client;
 
     protected function setUp(): void
     {
-        $this->mockHandler = new MockHandler();
+        $this->mockHandler = new AwsMockHandler();
 
         $awsCredentials = new Credentials('AWS_ACCESS_KEY', 'AWS_SECRET_KEY');
 

--- a/tests/ResourceOwnerObjectReturnedFromMethodsTest.php
+++ b/tests/ResourceOwnerObjectReturnedFromMethodsTest.php
@@ -4,7 +4,7 @@ namespace Dvsa\Authentication\Cognito\Tests;
 
 use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
 use Aws\Credentials\Credentials;
-use Aws\MockHandler;
+use Aws\MockHandler as AwsMockHandler;
 use Aws\Result;
 use Dvsa\Authentication\Cognito\Client;
 use Dvsa\Authentication\Cognito\CognitoUser;
@@ -17,19 +17,13 @@ class ResourceOwnerObjectReturnedFromMethodsTest extends TestCase
 {
     const RESOURCE_OWNER = CognitoUser::class;
 
-    /**
-     * @var MockHandler
-     */
-    protected $mockHandler;
+    protected AwsMockHandler $mockHandler;
 
-    /**
-     * @var Client
-     */
-    protected $client;
+    protected Client $client;
 
     protected function setUp(): void
     {
-        $this->mockHandler = new MockHandler();
+        $this->mockHandler = new AwsMockHandler();
 
         $awsCredentials = new Credentials('AWS_ACCESS_KEY', 'AWS_SECRET_KEY');
 
@@ -79,10 +73,10 @@ class ResourceOwnerObjectReturnedFromMethodsTest extends TestCase
 
         // Assert the correct values are set on the `$response` object.
         $this->assertEquals($response->getUsername(), 'USERNAME');
-        $this->assertEquals($response->enabled, 'true');
-        $this->assertEquals($response->created_date, 'USER_CREATED_DATE');
-        $this->assertEquals($response->last_modified_date, 'USER_LAST_MODIFIED_DATE');
-        $this->assertEquals($response->status, 'USER_STATUS');
+        $this->assertEquals($response->{'enabled'}, 'true');
+        $this->assertEquals($response->{'created_date'}, 'USER_CREATED_DATE');
+        $this->assertEquals($response->{'last_modified_date'}, 'USER_LAST_MODIFIED_DATE');
+        $this->assertEquals($response->{'status'}, 'USER_STATUS');
         $this->assertEquals($response->{'NAME_1'}, 'VALUE_1');
         $this->assertEquals($response->{'NAME_2'}, 'VALUE_2');
     }
@@ -118,10 +112,10 @@ class ResourceOwnerObjectReturnedFromMethodsTest extends TestCase
         $this->assertInstanceOf(self::RESOURCE_OWNER, $response);
 
         $this->assertEquals($response->getUsername(), 'USERNAME');
-        $this->assertEquals($response->enabled, 'true');
-        $this->assertEquals($response->created_date, 'USER_CREATED_DATE');
-        $this->assertEquals($response->last_modified_date, 'USER_LAST_MODIFIED_DATE');
-        $this->assertEquals($response->status, 'USER_STATUS');
+        $this->assertEquals($response->{'enabled'}, 'true');
+        $this->assertEquals($response->{'created_date'}, 'USER_CREATED_DATE');
+        $this->assertEquals($response->{'last_modified_date'}, 'USER_LAST_MODIFIED_DATE');
+        $this->assertEquals($response->{'status'}, 'USER_STATUS');
         $this->assertEquals($response->{'NAME_1'}, 'VALUE_1');
         $this->assertEquals($response->{'NAME_2'}, 'VALUE_2');
     }

--- a/tests/TokenValidityTest.php
+++ b/tests/TokenValidityTest.php
@@ -48,15 +48,9 @@ X4nLcSbZtO0tcDGMfMpWF2JGYOEJQNetPozL/ICGVFyIO8yzXm8U
 -----END RSA PRIVATE KEY-----
 EOF;
 
-    /**
-     * @var Client|MockObject
-     */
-    protected $client;
+    protected Client $client;
 
-    /**
-     * @var MockHttpHandler
-     */
-    protected $mockHttpHandler;
+    protected MockHttpHandler $mockHttpHandler;
 
     protected function setUp(): void
     {

--- a/tests/TokenValidityTest.php
+++ b/tests/TokenValidityTest.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler as MockHttpHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -67,16 +67,18 @@ EOF;
         $this->client = new Client($cognitoIdentityProviderMock, 'CLIENT_ID', 'CLIENT_SECRET', 'POOL_ID');
 
         $this->client->setJwtWebKeys(
-            JWK::parseKeySet([
-                'keys' => [[
-                    "kid" => "1234example=",
-                    "alg" => "RS256",
-                    "kty" => "RSA",
-                    "e" => "AQAB",
-                    "n" => "0Ttga33B1yX4w77NbpKyNYDNSVCo8j-RlZaZ9tI-KfkV1d-tfsvI9ZPAheP11FoN52ceBaY5ltelHW-IKwCfyT0orLdsxLgowaXki9woF1Azvcg2JVxQLv9aVjjAvy3CZFIG_EeN7J3nsyCXGnu1yMEbnvkWxA88__Q6HQ2K9wqfApkQ0LNlsK0YHz_sfjHNvRKxnbAJk7D5fUhZunPZXOPHXFgA5SvLvMaNIXduMKJh4OMfuoLdJowXJAR9j31Mqz_is4FMhm_9Mq7vZZ-uF09htRvIR8tRY28oJuW1gKWyg7cQQpnjHgFyG3XLXWAeXclWqyh_LfjyHQjrYhyeFw",
-                    "use" => "sig",
-                ]]
-            ])
+            new Collection(
+                JWK::parseKeySet([
+                    'keys' => [[
+                        "kid" => "1234example=",
+                        "alg" => "RS256",
+                        "kty" => "RSA",
+                        "e" => "AQAB",
+                        "n" => "0Ttga33B1yX4w77NbpKyNYDNSVCo8j-RlZaZ9tI-KfkV1d-tfsvI9ZPAheP11FoN52ceBaY5ltelHW-IKwCfyT0orLdsxLgowaXki9woF1Azvcg2JVxQLv9aVjjAvy3CZFIG_EeN7J3nsyCXGnu1yMEbnvkWxA88__Q6HQ2K9wqfApkQ0LNlsK0YHz_sfjHNvRKxnbAJk7D5fUhZunPZXOPHXFgA5SvLvMaNIXduMKJh4OMfuoLdJowXJAR9j31Mqz_is4FMhm_9Mq7vZZ-uF09htRvIR8tRY28oJuW1gKWyg7cQQpnjHgFyG3XLXWAeXclWqyh_LfjyHQjrYhyeFw",
+                        "use" => "sig",
+                    ]]
+                ])
+            )
         );
     }
 
@@ -153,7 +155,7 @@ EOF;
 
     public function testDecodeWillThrowExceptionWhenUnableToFetchJwtWebKeys(): void
     {
-        $this->client->setJwtWebKeys([]);
+        $this->client->setJwtWebKeys(null);
 
         $mockHttpHandler = new MockHttpHandler();
         $exceptionMessage = 'Error Communicating with Server';
@@ -164,7 +166,7 @@ EOF;
         $this->client->setHttpClient($httpClient);
 
         $this->expectException(InvalidTokenException::class);
-        $this->expectErrorMessage(sprintf('Unable to fetch JWT web keys: %s', $exceptionMessage));
+        $this->expectErrorMessage($exceptionMessage);
 
         $this->client->decodeToken('');
     }


### PR DESCRIPTION
**Description of the change:**
- Removes support for PHP 7.2 & 7.3, and adds 8.1 to CI - BREAKING.
- Uses new functionality in `firebase/jwt` to cache the JWK when provided with a PSR 6 Cache interface.
- Fix security issues identified by Snyk

